### PR TITLE
feat: nelmio

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -44,5 +44,6 @@ nelmio_api_doc:
                         '200':
                             description: OK
     areas: # to filter documented areas
-        path_patterns:
-            - ^/api(?!/doc$) # Accepts routes under /api except /api/doc
+        default:
+            path_patterns: [ ^/api/user, ^/api/surveys, ^/api/login_check ]
+#            - ^/api(?!/doc$) # Accepts routes under /api except /api/doc

--- a/src/Controller/AnswerController.php
+++ b/src/Controller/AnswerController.php
@@ -32,7 +32,7 @@ class AnswerController extends AbstractController
      *     description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *     @SWG\Schema(
      *         type="array",
-     *         @SWG\Items(ref=@Model(type=Answer::class, groups={"answer_list"}))
+     *         @SWG\Items(ref=@Model(type=Answer::class))
      *     )
      * )
      * @SWG\Response(

--- a/src/Controller/QuestionController.php
+++ b/src/Controller/QuestionController.php
@@ -32,7 +32,7 @@ class QuestionController extends AbstractController
      *     description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *     @SWG\Schema(
      *         type="array",
-     *         @SWG\Items(ref=@Model(type=Question::class, groups={"question_show"}))
+     *         @SWG\Items(ref=@Model(type=Question::class))
      *     )
      * )
      * @SWG\Response(
@@ -78,7 +78,7 @@ class QuestionController extends AbstractController
      *     description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *     @SWG\Schema(
      *         type="array",
-     *         @SWG\Items(ref=@Model(type=Question::class, groups={"question_show"}))
+     *         @SWG\Items(ref=@Model(type=Question::class))
      *     )
      * )
      * @SWG\Response(

--- a/src/Controller/SurveyController.php
+++ b/src/Controller/SurveyController.php
@@ -40,7 +40,7 @@ class SurveyController extends AbstractController
      *     description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *     @SWG\Schema(
      *         type="array",
-     *         @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *         @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
@@ -114,7 +114,7 @@ class SurveyController extends AbstractController
      *     description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *     @SWG\Schema(
      *         type="array",
-     *         @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *         @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
@@ -165,14 +165,14 @@ class SurveyController extends AbstractController
      *    description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *    @SWG\Schema(
      *       type="array",
-     *       @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *       @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
      *     response=201,
      *     description="`Created`. Response to a POST that results in a creation. Should be combined with a Location header pointing to the location of the new resource.",
      *     @SWG\Schema(
-     *         @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *         @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
@@ -233,14 +233,14 @@ class SurveyController extends AbstractController
      *    description="Response to a successful GET, PUT, PATCH or DELETE. Can also be used for a POST that doesn't result in a creation.",
      *    @SWG\Schema(
      *       type="array",
-     *       @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *       @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
      *     response=201,
      *     description="`Created`. Response to a POST that results in a creation. Should be combined with a Location header pointing to the location of the new resource.",
      *     @SWG\Schema(
-     *         @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *         @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @SWG\Response(
@@ -294,7 +294,7 @@ class SurveyController extends AbstractController
      *    description="`No Content`. Response to a successful request that won't be returning a body (like a DELETE request).",
      *    @SWG\Schema(
      *       type="array",
-     *       @SWG\Items(ref=@Model(type=Survey::class, groups={"survey_list"}))
+     *       @SWG\Items(ref=@Model(type=Survey::class))
      *     )
      * )
      * @nSecurity(name="Bearer")


### PR DESCRIPTION
- Remove group for item sawgger schema to prevent duplicate model in the documentation.
- Add plain route for all endpoint. This is the skill to remove the default route.